### PR TITLE
feat: delegate query guardrails entirely to LLM prompts

### DIFF
--- a/backend/agent/prompts.py
+++ b/backend/agent/prompts.py
@@ -1,0 +1,65 @@
+ANALYSIS_PROMPT_TEMPLATE = """
+You are a highly skilled gaming retention analyst.
+Given the player data and ML prediction below, explain why this player may churn.
+
+Player data:
+{player_data}
+
+ML prediction:
+{prediction}
+
+Return valid JSON with this exact shape:
+{{
+  "engagement_analysis": "2-4 sentence explanation in clear language",
+  "key_risk_factors": ["factor 1", "factor 2", "factor 3"],
+  "confidence_level": "high" | "medium" | "low"
+}}
+
+Rules:
+- Be specific to the data.
+- Do not invent features not present in the player data.
+- Keep factors actionable and easy to understand.
+"""
+
+REPORT_PROMPT_TEMPLATE = """
+You are creating a structured churn-risk report for a gaming analytics product.
+
+User question: {user_query}
+
+Player data:
+{player_data}
+
+ML prediction:
+{prediction}
+
+Analysis:
+{analysis}
+
+Industry research:
+{industry_best_practices}
+
+CRITICAL INSTRUCTIONS FOR USER QUESTION:
+1. SPELLING ERROR CORRECTION: Actively interpret and fix any spelling mistakes or typos in the user's question (e.g., "playre chrun" -> "player churn", "imporve" -> "improve").
+2. "ABOUT MYSELF" RULE: If the user asks "tell me about myself", "who am I", "my stats", etc., TREAT the provided Player data as "themselves" and summarize their gaming profile, Level, and churn risk. THIS IS FULLY ON-TOPIC. Answer it directly based on the data.
+3. OFF-TOPIC GUARDRAIL: Only if the question is COMPLETELY unrelated to gaming, player engagement, or the player data (e.g., "What's the weather?", "How to bake a cake", "capital of France"), you MUST decline.
+   - For off-topic questions, write EXACTLY this in the `direct_answer_to_user` field: "I'm specialized in player churn analysis and game engagement strategies. Please ask a question related to this player's gaming behavior or retention."
+4. RELEVANT QUERIES: If the question IS related to the player or gaming, analyze their stats and answer directly and insightfully in the `direct_answer_to_user` field.
+
+Return valid JSON with this exact shape:
+{{
+  "direct_answer_to_user": "Clear, direct paragraph directly answering the User question (or the off-topic rejection message)",
+  "executive_summary": "2-3 sentence overview",
+  "engagement_analysis": "clear explanation",
+  "key_risk_factors": ["factor 1", "factor 2"],
+  "personalized_strategies": ["strategy 1", "strategy 2", "strategy 3"],
+  "industry_best_practices": ["practice 1", "practice 2"],
+  "sources": ["https://..."],
+  "disclaimers": ["ethical disclaimer 1", "UX disclaimer 2"],
+  "confidence_level": "high" | "medium" | "low"
+}}
+
+Rules:
+- Keep recommendations grounded in the player profile.
+- Do not invent URLs or citations.
+- Include ethical disclaimers about AI-generated predictions and player data privacy.
+"""

--- a/backend/agent/workflow.py
+++ b/backend/agent/workflow.py
@@ -20,6 +20,7 @@ from typing import Any, TypedDict
 
 import pandas as pd
 
+from backend.agent.prompts import ANALYSIS_PROMPT_TEMPLATE, REPORT_PROMPT_TEMPLATE
 from backend.ml.feature_engineering import run_feature_engineering
 from backend.ml.predict import predict_single
 
@@ -46,34 +47,6 @@ except ImportError:  # pragma: no cover - optional dependency at runtime
 load_dotenv()
 
 logger = logging.getLogger(__name__)
-
-# Keywords that indicate a gaming / churn / engagement related question
-_RELEVANT_KEYWORDS = {
-    "churn", "player", "game", "gaming", "engagement", "retention", "session",
-    "play", "level", "achievement", "purchase", "risk", "score", "strategy",
-    "recommend", "inactive", "active", "quit", "leave", "return", "comeback",
-    "reward", "offer", "notification", "progression", "difficulty", "genre",
-    "duration", "frequency", "behavior", "behaviour", "predict", "analysis",
-    "why", "how", "what", "factor", "reason", "cause", "improve", "reduce",
-    "increase", "decrease", "save", "lose", "losing", "engaged", "disengaged",
-    "monetization", "spending", "revenue", "ltv", "lifetime", "loyalty",
-}
-
-_OFF_TOPIC_RESPONSE = (
-    "I'm specialized in player churn analysis and game engagement strategies. "
-    "Your question doesn't appear to be related to this player's gaming behavior. "
-    "Please ask about churn risk factors, engagement patterns, or retention strategies "
-    "for this player profile."
-)
-
-
-def _is_relevant_query(query: str | None) -> bool:
-    """Return True if the query is related to gaming / churn / engagement."""
-    if not query or not query.strip():
-        return True  # empty query = use default dynamic query
-    words = set(query.lower().split())
-    return bool(words & _RELEVANT_KEYWORDS)
-
 
 def get_dynamic_query(risk_level: str) -> str:
     if risk_level == "HIGH":
@@ -349,7 +322,6 @@ def _build_query_focused_answer(user_query: str | None, player_data: dict[str, A
     )
 
 
-
 def _fallback_report(state: AgentState) -> dict[str, Any]:
     best_practices = state.get("industry_best_practices") or _local_best_practices(
         state["player_data"], state["ml_prediction"]
@@ -388,110 +360,15 @@ def _fallback_report(state: AgentState) -> dict[str, Any]:
     }
 
 
-def _build_analysis_prompt(player_data: dict[str, Any], prediction: dict[str, Any]) -> str:
-    return f"""
-You are a gaming retention analyst.
-Given the player data and ML prediction below, explain why this player may churn.
-
-Player data:
-{json.dumps(player_data, indent=2)}
-
-ML prediction:
-{json.dumps(prediction, indent=2)}
-
-Return valid JSON with this exact shape:
-{{
-  "engagement_analysis": "2-4 sentence explanation in clear language",
-  "key_risk_factors": ["factor 1", "factor 2", "factor 3"],
-  "confidence_level": "high" | "medium" | "low"
-}}
-
-Rules:
-- Be specific to the data.
-- Do not invent features not present in the player data.
-- Keep factors actionable and easy to understand.
-"""
-
-
-def _build_report_prompt(state: AgentState) -> str:
-    return f"""
-You are creating a structured churn-risk report for a gaming analytics product.
-
-User question:
-{state.get("user_query") or get_dynamic_query(state.get("ml_prediction", {}).get("risk_level", "MEDIUM"))}
-
-Player data:
-{json.dumps(state["player_data"], indent=2)}
-
-ML prediction:
-{json.dumps(state["ml_prediction"], indent=2)}
-
-Analysis:
-{json.dumps({
-    "engagement_analysis": state["engagement_analysis"],
-    "key_risk_factors": state["key_risk_factors"],
-    "confidence_level": state["confidence_level"],
-}, indent=2)}
-
-Industry research:
-{json.dumps(state.get("industry_best_practices", []), indent=2)}
-
-Return valid JSON with this exact shape:
-{{
-  "direct_answer_to_user": "Clear, direct paragraph directly answering the User question",
-  "executive_summary": "2-3 sentence overview",
-  "engagement_analysis": "clear explanation",
-  "key_risk_factors": ["factor 1", "factor 2"],
-  "personalized_strategies": ["strategy 1", "strategy 2", "strategy 3"],
-  "industry_best_practices": ["practice 1", "practice 2"],
-  "sources": ["https://..."],
-  "disclaimers": ["ethical disclaimer 1", "UX disclaimer 2"],
-  "confidence_level": "high" | "medium" | "low"
-}}
-
-Rules:
-- Keep recommendations grounded in the player profile.
-- Do not invent URLs or citations.
-- Include ethical disclaimers about AI-generated predictions and player data privacy.
-- If the user's question is NOT related to gaming, player engagement, churn prediction, or retention strategies, respond with: "I'm specialized in player churn analysis and game engagement strategies. Please ask a question related to this player's gaming behavior or retention."
-"""
-
-
 class ChurnAgent:
     def __init__(self, llm: Any | None = None):
         self.llm = llm
         self.app = self._compile_workflow()
 
     def invoke(self, state: AgentState) -> AgentState:
-        user_query = state.get("user_query")
-
-        # Guard: reject off-topic questions before running the full pipeline
-        if user_query and not _is_relevant_query(user_query):
-            return {
-                "player_data": state["player_data"],
-                "user_query": user_query,
-                "ml_prediction": {"churn_probability": 0.0, "will_churn": False, "risk_level": "LOW"},
-                "engagement_analysis": "",
-                "key_risk_factors": [],
-                "personalized_strategies": [],
-                "confidence_level": "low",
-                "warnings": ["Query is not related to gaming or player engagement."],
-                "final_report": {
-                    "direct_answer_to_user": _OFF_TOPIC_RESPONSE,
-                    "executive_summary": _OFF_TOPIC_RESPONSE,
-                    "engagement_analysis": "",
-                    "key_risk_factors": [],
-                    "personalized_strategies": [],
-                    "industry_best_practices": [],
-                    "sources": [],
-                    "disclaimers": _get_disclaimers(),
-                    "confidence_level": "low",
-                },
-            }
-
         initial_state: AgentState = {
             "player_data": state["player_data"],
-            "user_query": user_query,
+            "user_query": state.get("user_query"),
             "warnings": list(state.get("warnings", [])),
         }
         return self.app.invoke(initial_state)
@@ -543,9 +420,11 @@ class ChurnAgent:
             }
 
         try:
-            response = self.llm.invoke(
-                _build_analysis_prompt(state["player_data"], state["ml_prediction"])
+            prompt_str = ANALYSIS_PROMPT_TEMPLATE.format(
+                player_data=json.dumps(state["player_data"], indent=2),
+                prediction=json.dumps(state["ml_prediction"], indent=2),
             )
+            response = self.llm.invoke(prompt_str)
             payload = _safe_json_loads(getattr(response, "content", "")) or {}
             analysis = payload.get("engagement_analysis")
             factors = payload.get("key_risk_factors")
@@ -602,7 +481,22 @@ class ChurnAgent:
             }
 
         try:
-            response = self.llm.invoke(_build_report_prompt(state))
+            query_to_use = state.get("user_query") or get_dynamic_query(
+                state.get("ml_prediction", {}).get("risk_level", "MEDIUM")
+            )
+            analysis_dict = {
+                "engagement_analysis": state["engagement_analysis"],
+                "key_risk_factors": state["key_risk_factors"],
+                "confidence_level": state["confidence_level"],
+            }
+            prompt_str = REPORT_PROMPT_TEMPLATE.format(
+                user_query=query_to_use,
+                player_data=json.dumps(state["player_data"], indent=2),
+                prediction=json.dumps(state["ml_prediction"], indent=2),
+                analysis=json.dumps(analysis_dict, indent=2),
+                industry_best_practices=json.dumps(state.get("industry_best_practices", []), indent=2),
+            )
+            response = self.llm.invoke(prompt_str)
             payload = _safe_json_loads(getattr(response, "content", "")) or {}
             if not isinstance(payload, dict) or "executive_summary" not in payload:
                 raise ValueError("LLM returned incomplete report payload")


### PR DESCRIPTION
- Created backend/agent/prompts.py to cleanly manage agent instructions.
- Removed manual difflib fuzzy matching and regex keyword checks from workflow.py.
- Instructed LLM natively to fix spelling errors.
- Explicitly instructed LLM to treat 'tell me about myself' queries as fully on-topic requests for the player's own profile.